### PR TITLE
Configure TLS for LDAP and set correct ownership and permissions for LDAP and SSL directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,17 @@ RUN apt-get update && \
     net-tools \
     procps \
     traceroute \
-    tcpdump
+    tcpdump \
+    openssl
 
 # SSH Configuration
-RUN mkdir /var/run/sshd
-# Use port 2222 for SSH
-RUN echo 'Port 2222' >> /etc/ssh/sshd_config
-RUN echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
-RUN echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
-RUN echo 'UsePAM yes' >> /etc/ssh/sshd_config
+RUN mkdir /var/run/sshd && \
+    echo 'Port 2222' >> /etc/ssh/sshd_config && \
+    echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config && \
+    echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
+    echo 'UsePAM yes' >> /etc/ssh/sshd_config
 
-# Create local user mie with password 'mie'
+# Create a local user 'mie' with password 'mie' and sudo privileges
 RUN useradd -m -s /bin/bash mie && \
     echo 'mie:mie' | chpasswd && \
     echo 'mie ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers.d/mie
@@ -33,7 +33,7 @@ RUN useradd -m -s /bin/bash mie && \
 COPY users.ldif /etc/ldap/users.ldif
 COPY setup.ldif /etc/ldap/setup.ldif
 
-# Add default LDAP client config
+# Configure LDAP client
 RUN echo "BASE    dc=mieweb,dc=com" > /etc/ldap/ldap.conf && \
     echo "URI     ldap://localhost" >> /etc/ldap/ldap.conf && \
     echo "BINDDN  cn=admin,dc=mieweb,dc=com" >> /etc/ldap/ldap.conf && \
@@ -57,6 +57,30 @@ RUN slapadd < /etc/ldap/users.ldif
 # Configure SSSD
 COPY sssd.conf /etc/sssd/sssd.conf
 RUN chmod 600 /etc/sssd/sssd.conf
+
+# Configure LDAP TLS settings
+COPY enable-tls.ldif /etc/ldap/enable-tls.ldif
+
+# Set appropriate permissions for LDAP directories
+RUN chown -R openldap:openldap /etc/ldap/slapd.d && \
+    chmod -R 750 /etc/ldap/slapd.d && \
+    chmod 755 /etc/ssl/private && \
+    chmod 755 /etc/ssl/certs
+
+# Generate certificates for TLS
+RUN openssl req -new -x509 -nodes -out /etc/ssl/certs/ldap-cert.pem -keyout /etc/ssl/private/ldap-key.pem -days 365 \
+    -subj "/C=US/ST=IN/L=City/O=MIE/CN=localhost" && \
+    cp /etc/ssl/certs/ldap-cert.pem /etc/ssl/certs/ca-cert.pem && \
+    chown openldap:openldap /etc/ssl/certs/ldap-cert.pem /etc/ssl/private/ldap-key.pem /etc/ssl/certs/ca-cert.pem && \
+    chmod 600 /etc/ssl/private/ldap-key.pem && \
+    chmod 644 /etc/ssl/certs/ldap-cert.pem /etc/ssl/certs/ca-cert.pem
+
+# Apply TLS configuration
+RUN slapd -h "ldapi:///" -u openldap -g openldap -d 256 & \
+    sleep 5 && \
+    ldapmodify -H ldapi:/// -Y EXTERNAL -f /etc/ldap/enable-tls.ldif && \
+    killall slapd && \
+    chmod 640 /etc/ssl/private/ldap-key.pem
 
 # Start services and set permissions
 CMD service slapd start && \

--- a/enable-tls.ldif
+++ b/enable-tls.ldif
@@ -1,0 +1,10 @@
+dn: cn=config
+changetype: modify
+replace: olcTLSCACertificateFile
+olcTLSCACertificateFile: /etc/ssl/certs/ca-cert.pem
+-
+replace: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/ssl/certs/ldap-cert.pem
+-
+replace: olcTLSCertificateKeyFile
+olcTLSCertificateKeyFile: /etc/ssl/private/ldap-key.pem

--- a/sssd.conf
+++ b/sssd.conf
@@ -14,3 +14,6 @@ ldap_default_authtok = secret
 ldap_tls_reqcert = never
 cache_credentials = true
 enumerate = true
+ldap_id_use_start_tls = true
+ldap_tls_cacert = /etc/ssl/certs/ca-cert.pem
+


### PR DESCRIPTION
**DONE**

- Added `enable-tls.ldif` file to configure TLS settings for LDAP securely.
- Adjusted permissions and ownership for `/etc/ldap/slapd.d` to ensure slapd starts without permission issues.
- Set permissions for `/etc/ssl/private` and `/etc/ssl/certs` to allow access during LDAP operations.
- Updated Dockerfile to automate the generation and installation of TLS certificates.
- Configured SSH settings in `sshd_config` to allow LDAP user authentication using SSSD.
- Applied necessary changes to SSSD configuration (`sssd.conf`) to integrate LDAP for user and password management.
