### PR TITLE
Refactor Dockerfile to centralize configuration using environment variables

### DIFF
--- a/ldap_env.sh
+++ b/ldap_env.sh
@@ -1,0 +1,9 @@
+# LDAP Environment Configuration
+export LDAP_BASE="dc=mieweb,dc=com"
+export LDAP_DOMAIN="mieweb.com"
+export LDAP_ORG="MIE"
+export LDAP_ADMIN_DN="cn=admin,dc=mieweb,dc=com"
+export LDAP_ADMIN_PW="secret"
+export SSH_PORT=2222
+export LDAP_CERT_SUBJ="/C=US/ST=IN/L=City/O=MIE/CN=localhost"
+export LDAP_URI="ldap://localhost"


### PR DESCRIPTION
**DONE**

- Moved constants such as LDAP base, domain, organization, admin DN, admin password, SSH port, and LDAP URI into an environment file (`ldap_env.sh`).
- Updated Dockerfile to source environment variables from `ldap_env.sh` for better maintainability and clarity.
- Adjusted LDAP client configuration, TLS certificate generation, and SSH settings to use these environment variables.
- This refactor ensures that configuration values are centralized, making future modifications easier and avoiding hardcoded constants directly in the Dockerfile.
- Improved readability and consistency across the Docker build process.
